### PR TITLE
feat: add createCardholder and updateCardholder

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "name": "act365 bookings list",
       "type": "debugpy",
       "request": "launch",
-      "program": ".venv/bin/act365",
+      "program": "src/act365/cli.py",
       "console": "integratedTerminal",
       "args": [
         "-v",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`act365` is a Python client library and CLI for the [ACT365](https://www.act365.eu/) access control API. It is published to PyPI and managed with Poetry.
+
+## Commands
+
+### Setup
+```bash
+poetry install --with dev
+```
+
+### Run Tests
+```bash
+poetry run pytest
+```
+
+Tests that make real API calls are skipped unless `ACT365_USERNAME` and `ACT365_PASSWORD` env vars are set.
+
+Run a single test:
+```bash
+poetry run pytest tests/test_client.py::TestBookingClient::test_get_booking
+```
+
+### Lint
+```bash
+flake8 .
+isort .
+```
+
+Pre-commit hooks run black, isort, flake8, and poetry checks automatically.
+
+### Run the CLI
+```bash
+act365 --username $ACT365_USERNAME --password $ACT365_PASSWORD --siteid $ACT365_SITEID bookings list
+act365 bookings get --id <bookingid>
+act365 bookings delete --id <bookingid>
+act365 bookings delete --expired
+```
+
+CLI credentials can also be provided via `ACT365_USERNAME`, `ACT365_PASSWORD`, `ACT365_SITEID` env vars.
+
+## Architecture
+
+The package lives in `src/act365/` and has four main modules:
+
+- **`client.py`** — `Act365Client` is the main entrypoint. It wraps `httpx.Client` with `Act365Auth` (a custom `httpx.Auth` subclass that handles bearer token login, automatic retry on 401, and rate-limit backoff on 429). Pagination is handled via the `_getAll()` helper which uses `skipover`/`maxlimit` params.
+
+- **`booking.py`** — Dataclasses for `Booking`, `BookingSite`, `BookingDoor`, `BookingAddress`, `BookingContact`. `Booking` stores `StartValidity`/`EndValidity` internally as `datetime` and exposes them as strings in `DD/MM/YYYY HH:MM` format (`STRPTIME_FMT`). The `dict()` method on `Booking` serializes for the API, handling the quirk where a single door must be sent as `DoorID` (int) rather than `DoorIDs` (list).
+
+- **`cardholder.py`** — `CardHolder` is a dict-to-object mapper that merges API responses with an `empty` template. Uses property setters for `StartValid`/`EndValid` date parsing.
+
+- **`cli.py`** — Click-based CLI with a `cli` group and a `bookings` subgroup. The `cli` group initialises credentials and stores them in `ctx.obj`. Verbosity flag (`-v`/`-vv`/`-vvv`) maps to WARNING/INFO/DEBUG.
+
+## API Notes
+
+API documentation: https://act365api.docs.apiary.io/#
+
+
+- Base URL: `https://userapi.act365.eu/api`
+- Auth: POST to `/account/login` with form-encoded `grant_type`, `username`, `password` → returns `access_token`
+- Date format throughout: `DD/MM/YYYY HH:MM` (defined as `STRPTIME_FMT` in `booking.py`)
+- The ACT365 API returns `DoorID` (singular int) when a booking has only one door, and `DoorIDs` (list) otherwise — the `Booking` dataclass handles this via `InitVar[DoorID]`
+- `deleteBooking` posts to `url + "2/Bookings"` (note the "2" suffix — this is intentional)
+
+## Release Process
+
+Releases are managed by [release-please](https://github.com/googleapis/release-please). Commits must follow [Conventional Commits](https://www.conventionalcommits.org/). Merging a release PR to `main` triggers the publish workflow to PyPI.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Minimal httpx based client for the [ACT365](https://www.act365.eu/) API.
 
+API documentation: https://act365api.docs.apiary.io/#
+
 Published pn PyPI: https://pypi.org/project/act365/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "act365"
 # version is maintained by release-please, via the release-please-action & .release-please-manifest.json
-version = "1.3.1"
+version = "1.4.0"
 description = "Python Client for ACT365"
 authors = [{ name = "Simon McCartney", email = "simon@mccartney.ie" }]
 requires-python = ">=3.11,<4.0"
@@ -27,6 +27,9 @@ pytest-httpx = "^0.30.0"
 httpx = {extras = ["cli"], version = "^0.27.0"}
 flake8 = "^7.1.1"
 isort = "^5.13.2"
+
+[tool.pytest.ini_options]
+addopts = "-s"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/act365/cardholder.py
+++ b/src/act365/cardholder.py
@@ -65,6 +65,14 @@ class CardHolder(object):
         merged = dict(list(empty.items()) + list(dictionary.items()))
         for key in merged:
             setattr(self, key, merged[key])
+        if not self.SiteID:
+            raise ValueError("CardHolder SiteID is required")
+        if not self.CustomerID:
+            raise ValueError("CardHolder CustomerID is required")
+        if not self.Groups:
+            raise ValueError("CardHolder must belong to at least one Group")
+        if len(self.Cards) > 4:
+            raise ValueError("CardHolder can have at most 4 cards")
 
     def __repr__(self):
         return "<dict2obj: %s>" % self.__dict__
@@ -96,3 +104,9 @@ class CardHolder(object):
             self._EndValid_dt = value
         else:
             self._EndValid_dt = datetime.datetime.strptime(value, STRPTIME_FMT)
+
+    def dict(self) -> dict:
+        result = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+        result["StartValid"] = self.StartValid
+        result["EndValid"] = self.EndValid
+        return result

--- a/src/act365/cli.py
+++ b/src/act365/cli.py
@@ -110,7 +110,7 @@ def list(ctx, datefrom):
     click.echo(f"Found {len(bookings)} bookings")
 
     if len(bookings) > 0:
-        booking_fmt = "{:<10} {:<10} {:<50} {:<18} {:<18} {:<18}"
+        booking_fmt = "{:<10} {:<10} {:<50} {:<18} {:<18} {:<5} {:<10} {:<18}"
         print(
             booking_fmt.format(
                 "BookingID",
@@ -119,11 +119,13 @@ def list(ctx, datefrom):
                 "Start",
                 "End",
                 "PIN",
+                "Doors",
                 "Creation",
             )
         )
 
         for booking in bookings:
+            LOG.debug(f"Booking: {booking}")
             click.echo(
                 booking_fmt.format(
                     booking.BookingID,
@@ -132,6 +134,7 @@ def list(ctx, datefrom):
                     booking.StartValidity,
                     booking.EndValidity,
                     booking.PIN,
+                    ",".join(str(door) for door in booking.DoorIDs),
                     booking.BookingCreatedTime,
                 )
             )

--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -123,7 +123,10 @@ class Act365Client:
             self.url + "/Bookings", params={"siteid": siteid, "bookingID": id}
         )
         LOG.debug(f"Response: {response.status_code} {response.text}")
-        if response.text == "null":
+        if response.text == "null" or response.status_code != httpx.codes.OK:
+            LOG.error(
+                f"Failed to get booking {id}, {response.status_code}, {response.text}"
+            )
             return None
         else:
             return Booking(**json.loads(response.text))

--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -54,7 +54,14 @@ class Act365Client:
                     more_to_get = False
 
                 for ch in cardholders:
-                    self._CardHolders.append(CardHolder(ch))
+                    try:
+                        if ch.get("SiteID") == 0 or ch.get("SiteID") is None:
+                            ch["SiteID"] = self.siteid
+                        self._CardHolders.append(CardHolder(ch))
+                    except ValueError as e:
+                        LOG.warning(
+                            f"Skipping cardholder {ch.get('CardHolderID')}: {e}"
+                        )
 
             else:
                 more_to_get = False
@@ -72,6 +79,43 @@ class Act365Client:
         for ch in self._CardHolders:
             if ch.CardHolderID == id:
                 return ch
+
+    def createCardholder(self, cardholder: CardHolder | dict) -> int | None:
+        if isinstance(cardholder, dict):
+            data = cardholder
+        elif isinstance(cardholder, CardHolder):
+            data = cardholder.dict()
+        else:
+            raise TypeError("cardholder must be a CardHolder object or a dictionary")
+
+        response = self.client.post(self.url + "/cardholder", json=data)
+        LOG.debug(f"createCardholder response: {response.status_code} {response.text}")
+        if response.status_code == httpx.codes.OK:
+            body = response.json()
+            if body.get("Success"):
+                return body.get("NewID")
+        LOG.error(
+            f"Failed to create cardholder: {response.status_code} {response.text}"
+        )
+        return None
+
+    def updateCardholder(self, cardholder: CardHolder | dict) -> bool:
+        if isinstance(cardholder, dict):
+            data = cardholder
+        elif isinstance(cardholder, CardHolder):
+            data = cardholder.dict()
+        else:
+            raise TypeError("cardholder must be a CardHolder object or a dictionary")
+
+        response = self.client.put(self.url + "/cardholder", json=data)
+        LOG.debug(f"updateCardholder response: {response.status_code} {response.text}")
+        if response.status_code == httpx.codes.OK and response.json().get(
+            "Success", False
+        ):
+            return True
+        body = response.json()
+        error_msg = body.get("ErrorMsg", f"HTTP {response.status_code}")
+        raise ValueError(f"Failed to update cardholder: {error_msg}")
 
     def getBookingSites(self, maxlimit=100, skipover=0):
         params = {"maxlimit": maxlimit, "skipover": skipover}

--- a/tests/test_cardholder.py
+++ b/tests/test_cardholder.py
@@ -1,3 +1,5 @@
+import pytest
+
 from act365.cardholder import CardHolder
 
 me = {
@@ -39,3 +41,61 @@ def test_cardholder():
     cardholder.EndValid = rt["EndValid"]
     assert cardholder.StartValid == rt["StartValid"]
     assert cardholder.EndValid == rt["EndValid"]
+
+
+def test_cardholder_dict():
+    cardholder = CardHolder(
+        {
+            "CardHolderID": 21274334,
+            "CustomerID": 5622,
+            "SiteID": 8539,
+            "Groups": [27470],
+            "Forename": "Simon",
+            "Surname": "McCartney",
+            "Email": "simon@mccartney.ie",
+            "PIN": "1234",
+        }
+    )
+    cardholder.StartValid = rt["StartValid"]
+    cardholder.EndValid = rt["EndValid"]
+
+    d = cardholder.dict()
+
+    assert d["Forename"] == "Simon"
+    assert d["Surname"] == "McCartney"
+    assert d["Email"] == "simon@mccartney.ie"
+    assert d["PIN"] == "1234"
+    assert d["Groups"] == [27470]
+    assert d["StartValid"] == rt["StartValid"]
+    assert d["EndValid"] == rt["EndValid"]
+    assert d["CardHolderID"] == 21274334
+    # private datetime attributes should not be in the dict
+    assert "_StartValid_dt" not in d
+    assert "_EndValid_dt" not in d
+
+
+def test_cardholder_requires_siteid():
+    with pytest.raises(ValueError, match="SiteID"):
+        CardHolder({"CustomerID": 5622, "Groups": [27470]})
+
+
+def test_cardholder_requires_customerid():
+    with pytest.raises(ValueError, match="CustomerID"):
+        CardHolder({"SiteID": 8539, "Groups": [27470]})
+
+
+def test_cardholder_requires_group():
+    with pytest.raises(ValueError, match="Group"):
+        CardHolder({"SiteID": 8539, "CustomerID": 5622})
+
+
+def test_cardholder_max_4_cards():
+    with pytest.raises(ValueError, match="4 cards"):
+        CardHolder(
+            {
+                "SiteID": 8539,
+                "CustomerID": 5622,
+                "Groups": [27470],
+                "Cards": [1, 2, 3, 4, 5],
+            }
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -137,11 +137,17 @@ class TestBookingClient:
         assert response.json().get("Success") is True
         assert response.json().get("BookingID") > 0
 
-        bookings = act365_client.getBookings(me.get("SiteID"))
-        assert len(bookings) > 0
-        assert bookings[0].BookingID > 0
+        r = act365_client.getBooking(me.get("SiteID"), response.json().get("BookingID"))
+        assert r.BookingID == response.json().get("BookingID")
+        assert r.Forename == booking_dict.get("Forename")
+        # ACT365 appents a unique number to the surname
+        assert r.Surname.startswith(booking_dict.get("Surname"))
+        assert r.PIN == booking_dict.get("PIN")
+        assert r.StartValidity == booking_dict.get("StartValidity")
+        assert r.EndValidity == booking_dict.get("EndValidity")
+        assert r.DoorIDs == booking_dict.get("DoorIDs")
 
-        response = act365_client.deleteBooking(bookings[0].BookingID)
+        response = act365_client.deleteBooking(r.BookingID)
         assert response.json().get("Success") is True
 
     def test_client_simon(self, act365_client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ from random import randint
 import pytest
 
 from act365.booking import STRPTIME_FMT, Booking
+from act365.cardholder import CardHolder
 from act365.client import Act365Client
 
 me = {
@@ -150,6 +151,51 @@ class TestBookingClient:
         response = act365_client.deleteBooking(r.BookingID)
         assert response.json().get("Success") is True
 
+    def _create_test_cardholder(self, act365_client) -> int:
+        now = datetime.now()
+        cardholder = CardHolder(
+            {
+                "CustomerID": me.get("CustomerID"),
+                "SiteID": me.get("SiteID"),
+                "Forename": "Test",
+                "Surname": "Cardholder",
+                "Email": f"test+{now.strftime('%Y%m%d%H%M%S')}@example.com",
+                "PIN": f"{randint(0, 9999):04d}",
+                "Groups": me.get("Groups"),
+                "Card1": 0,
+                "Card2": 0,
+                "Enabled": True,
+                "StartValid": now.strftime(STRPTIME_FMT),
+                "EndValid": (now + timedelta(hours=1)).strftime(STRPTIME_FMT),
+            }
+        )
+        new_id = act365_client.createCardholder(cardholder)
+        assert new_id is not None
+        assert isinstance(new_id, int)
+        assert new_id > 0
+        return new_id
+
+    def test_create_cardholder(self, act365_client):
+        self._create_test_cardholder(act365_client)
+
+    def test_update_cardholder(self, act365_client):
+        new_id = self._create_test_cardholder(act365_client)
+        now = datetime.now()
+        cardholder = CardHolder(
+            {
+                "CardHolderID": new_id,
+                "CustomerID": me.get("CustomerID"),
+                "SiteID": me.get("SiteID"),
+                "Forename": "Test",
+                "Surname": "Cardholder",
+                "Groups": me.get("Groups"),
+                "StartValid": (now + timedelta(hours=2)).strftime(STRPTIME_FMT),
+                "EndValid": (now + timedelta(hours=3)).strftime(STRPTIME_FMT),
+            }
+        )
+        result = act365_client.updateCardholder(cardholder)
+        assert result is True
+
     def test_client_simon(self, act365_client):
         params = {
             "siteid": 8539,
@@ -166,7 +212,14 @@ class TestBookingClient:
         assert len(cardholders) > 2
 
     def test_get_by_email(self, act365_client):
+        import time
+
+        start = time.monotonic()
         cardholder = act365_client.getCardholderByEmail("simon@mccartney.ie")
+        elapsed = time.monotonic() - start
+
+        total = len(act365_client._CardHolders)
+        print(f"\nLoaded {total} cardholders in {elapsed:.2f}s to find by email")
 
         assert cardholder.Forename == "Simon"
         assert cardholder.Surname == "McCartney"


### PR DESCRIPTION
## Summary

- Adds `Act365Client.createCardholder()` (POST `/cardholder`) — returns the new `CardHolderID` on success
- Adds `Act365Client.updateCardholder()` (PUT `/cardholder`) — returns `True` or raises `ValueError` with the API error message
- Adds `CardHolder.dict()` for API serialisation, excluding private `_*_dt` datetime attributes
- Adds validation in `CardHolder.__init__`: `SiteID`, `CustomerID`, and `Groups` are required; max 4 cards enforced
- Patches missing `SiteID` (0 or None) in API responses using `client.siteid` so existing `getCardholders()` survives the new validation

## Test plan

- [ ] Unit tests: `test_cardholder_dict`, `test_cardholder_requires_siteid`, `test_cardholder_requires_customerid`, `test_cardholder_requires_group`, `test_cardholder_max_4_cards`
- [ ] Integration tests: `test_create_cardholder`, `test_update_cardholder` (require `ACT365_USERNAME`/`ACT365_PASSWORD` env vars)
- [ ] Existing `test_client_simon` and `test_get_by_email` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)