### PR TITLE
feat: add cardholders CLI commands (list, get)

### DIFF
--- a/src/act365/cardholder.py
+++ b/src/act365/cardholder.py
@@ -87,7 +87,7 @@ class CardHolder(object):
     @StartValid.setter
     def StartValid(self, value: str | None):
         if value is None or value == "":
-            self._StartValid_dt = value
+            self._StartValid_dt = None
         else:
             self._StartValid_dt = datetime.datetime.strptime(value, STRPTIME_FMT)
 
@@ -101,7 +101,7 @@ class CardHolder(object):
     @EndValid.setter
     def EndValid(self, value: str | None):
         if value is None or value == "":
-            self._EndValid_dt = value
+            self._EndValid_dt = None
         else:
             self._EndValid_dt = datetime.datetime.strptime(value, STRPTIME_FMT)
 

--- a/src/act365/cli.py
+++ b/src/act365/cli.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime
 
@@ -219,10 +220,122 @@ def delete(ctx, bookingids, expired, datefrom):
             click.echo(response)
 
 
+@click.group()
+@click.pass_context
+def cardholders(ctx):
+    ctx.ensure_object(dict)
+    pass
+
+
+@click.command(name="list")
+@click.pass_context
+@click.option(
+    "--search",
+    default=None,
+    help="Filter cardholders using the API search string (matches name, email, etc).",
+)
+@click.option(
+    "--enabled/--disabled",
+    "enabled",
+    default=None,
+    help="Only list enabled (or disabled) cardholders.",
+)
+@click.option(
+    "--all-sites",
+    is_flag=True,
+    help="List cardholders across all sites, including customer-level "
+    "cardholders (Managed By Site: All Sites) that a site-scoped "
+    "query excludes.",
+)
+def cardholders_list(ctx, search, enabled, all_sites):
+    ctx.ensure_object(dict)
+    act365_client = Act365Client(
+        username=ctx.obj["username"],
+        password=ctx.obj["password"],
+        siteid=ctx.obj["siteid"],
+    )
+
+    params = {} if all_sites else {"siteid": ctx.obj["siteid"]}
+    if search is not None:
+        params["searchString"] = search
+    if enabled is not None:
+        params["enabled"] = enabled
+
+    cardholders = act365_client.getCardholders(params=params)
+
+    click.echo(f"Found {len(cardholders)} cardholders")
+
+    if len(cardholders) > 0:
+        cardholder_fmt = "{:<12} {:<15} {:<25} {:<30} {:<8} {:<18} {:<18} {:<15}"
+        click.echo(
+            cardholder_fmt.format(
+                "CardHolderID",
+                "Forename",
+                "Surname",
+                "Email",
+                "Enabled",
+                "StartValid",
+                "EndValid",
+                "Cards",
+            )
+        )
+
+        for ch in cardholders:
+            LOG.debug(f"CardHolder: {ch}")
+            click.echo(
+                cardholder_fmt.format(
+                    ch.CardHolderID,
+                    ch.Forename or "",
+                    ch.Surname or "",
+                    ch.Email or "",
+                    str(ch.Enabled),
+                    ch.StartValid,
+                    ch.EndValid,
+                    ",".join(str(card) for card in ch.Cards),
+                )
+            )
+
+
+@click.command(name="get")
+@click.pass_context
+@click.option(
+    "--id",
+    type=int,
+    help="ACT365 CardHolder ID to get.",
+)
+@click.option(
+    "--email",
+    help="Email address of the cardholder to get.",
+)
+def cardholders_get(ctx, id, email):
+    ctx.ensure_object(dict)
+    if (id is None) == (email is None):
+        raise click.UsageError("Provide exactly one of --id or --email.")
+
+    act365_client = Act365Client(
+        username=ctx.obj["username"],
+        password=ctx.obj["password"],
+        siteid=ctx.obj["siteid"],
+    )
+
+    if id is not None:
+        cardholder = act365_client.getCardholderById(id)
+    else:
+        cardholder = act365_client.getCardholderByEmail(email)
+
+    if cardholder is None:
+        click.echo(f"Cardholder {id if id is not None else email} not found.")
+    else:
+        click.echo(json.dumps(cardholder.dict(), indent=2))
+
+
 cli.add_command(bookings)
 bookings.add_command(list)
 bookings.add_command(get)
 bookings.add_command(delete)
+cli.add_command(cardholders)
+cardholders.add_command(cardholders_list)
+cardholders.add_command(cardholders_get)
 
 if __name__ == "__main__":
     cli(obj={})

--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -71,7 +71,7 @@ class Act365Client:
     def getCardholderByEmail(self, email):
         self.getCardholders()
         for ch in self._CardHolders:
-            if ch.Email.lower() == email.lower():
+            if ch.Email and ch.Email.lower() == email.lower():
                 return ch
 
     def getCardholderById(self, id):

--- a/tests/test_cardholder.py
+++ b/tests/test_cardholder.py
@@ -74,6 +74,26 @@ def test_cardholder_dict():
     assert "_EndValid_dt" not in d
 
 
+def test_cardholder_empty_validity_dates():
+    # the API returns "" for cardholders with no validity dates; the
+    # getters must not blow up on them (regression: str has no strftime)
+    cardholder = CardHolder(
+        {
+            "CustomerID": 5622,
+            "SiteID": 8539,
+            "Groups": [27470],
+            "StartValid": "",
+            "EndValid": "",
+        }
+    )
+    assert cardholder.StartValid == ""
+    assert cardholder.EndValid == ""
+
+    d = cardholder.dict()
+    assert d["StartValid"] == ""
+    assert d["EndValid"] == ""
+
+
 def test_cardholder_requires_siteid():
     with pytest.raises(ValueError, match="SiteID"):
         CardHolder({"CustomerID": 5622, "Groups": [27470]})


### PR DESCRIPTION
## Summary

Adds a `cardholders` command group to the CLI so cardholder objects can be inspected from the terminal:

- `act365 cardholders list` — table of cardholders (ID, name, email, enabled, validity window, cards), with:
  - `--search <string>` — the API's search filter (case-insensitive, matches name and email)
  - `--enabled` / `--disabled`
  - `--all-sites` — include customer-level cardholders ("Managed By Site: All Sites", `SiteID=0`) that a site-scoped query silently excludes; this matches what the web UI search returns
- `act365 cardholders get --id <id>` / `--email <address>` — dumps the full cardholder object as pretty-printed JSON

## Bug fixes found while testing against the live API

- `CardHolder.StartValid`/`EndValid` setters stored the API's `""` values as-is, so the getters crashed with `AttributeError: 'str' object has no attribute 'strftime'` on any cardholder without validity dates (e.g. booking-generated ones). Empty values are now normalised to `None`; regression test added.
- `getCardholderByEmail` crashed with `AttributeError` on cardholders that have no email address.

## Testing

- 34 tests pass (including new `test_cardholder_empty_validity_dates`); flake8/black/isort clean
- Verified live: `list`, `list --search`, `list --search --all-sites` (matches the web UI result set exactly), `get --id`, `get --email`, and the not-found / usage-error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)