### PR TITLE
feat: add --sort-by option to cardholders list CLI

### DIFF
--- a/src/act365/cli.py
+++ b/src/act365/cli.py
@@ -227,6 +227,39 @@ def cardholders(ctx):
     pass
 
 
+CARDHOLDER_SORT_FIELDS = (
+    "CardHolderID",
+    "Forename",
+    "Surname",
+    "Email",
+    "Enabled",
+    "StartValid",
+    "EndValid",
+    "Cards",
+)
+
+
+def _cardholder_sort_key(sort_by):
+    def key(ch):
+        # Cardholders without a value for the field sort last; the leading
+        # flag keeps missing values out of the type-specific comparison.
+        if sort_by == "Cards":
+            cards = ch.Cards or []
+            return (0, min(cards)) if cards else (1, 0)
+        value = getattr(ch, sort_by)
+        if sort_by in ("StartValid", "EndValid"):
+            if not value:
+                return (1, 0)
+            return (0, datetime.strptime(value, booking_strptime_fmt))
+        if value is None:
+            return (1, 0)
+        if isinstance(value, str):
+            return (0, value.lower())
+        return (0, value)
+
+    return key
+
+
 @click.command(name="list")
 @click.pass_context
 @click.option(
@@ -247,7 +280,14 @@ def cardholders(ctx):
     "cardholders (Managed By Site: All Sites) that a site-scoped "
     "query excludes.",
 )
-def cardholders_list(ctx, search, enabled, all_sites):
+@click.option(
+    "--sort-by",
+    type=click.Choice(CARDHOLDER_SORT_FIELDS, case_sensitive=False),
+    default=None,
+    help="Sort the listing by the given field, ascending. Cards sorts by "
+    "the lowest card number; cardholders without a value sort last.",
+)
+def cardholders_list(ctx, search, enabled, all_sites, sort_by):
     ctx.ensure_object(dict)
     act365_client = Act365Client(
         username=ctx.obj["username"],
@@ -262,6 +302,9 @@ def cardholders_list(ctx, search, enabled, all_sites):
         params["enabled"] = enabled
 
     cardholders = act365_client.getCardholders(params=params)
+
+    if sort_by is not None:
+        cardholders = sorted(cardholders, key=_cardholder_sort_key(sort_by))
 
     click.echo(f"Found {len(cardholders)} cardholders")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,116 @@
+from click.testing import CliRunner
+
+from act365.cardholder import CardHolder
+from act365.cli import _cardholder_sort_key, cli
+
+
+def make_cardholder(**overrides):
+    base = {
+        "CustomerID": 5622,
+        "SiteID": 8539,
+        "Groups": [27470],
+    }
+    base.update(overrides)
+    return CardHolder(base)
+
+
+def test_sort_key_cards_ascending_by_lowest_card():
+    holders = [
+        make_cardholder(CardHolderID=1, Cards=[200]),
+        make_cardholder(CardHolderID=2, Cards=[]),
+        make_cardholder(CardHolderID=3, Cards=[100, 50]),
+    ]
+
+    ordered = sorted(holders, key=_cardholder_sort_key("Cards"))
+
+    # lowest card number first, cardholders without cards last
+    assert [ch.CardHolderID for ch in ordered] == [3, 1, 2]
+
+
+def test_sort_key_surname_case_insensitive_none_last():
+    holders = [
+        make_cardholder(CardHolderID=1, Surname="mccartney"),
+        make_cardholder(CardHolderID=2, Surname=None),
+        make_cardholder(CardHolderID=3, Surname="Abbott"),
+    ]
+
+    ordered = sorted(holders, key=_cardholder_sort_key("Surname"))
+
+    assert [ch.CardHolderID for ch in ordered] == [3, 1, 2]
+
+
+def test_sort_key_startvalid_chronological():
+    holders = [
+        make_cardholder(CardHolderID=1, StartValid="02/01/2025 00:00"),
+        make_cardholder(CardHolderID=2, StartValid=""),
+        # string-sorts after 02/01/2025 but is chronologically earlier
+        make_cardholder(CardHolderID=3, StartValid="31/12/2024 23:59"),
+    ]
+
+    ordered = sorted(holders, key=_cardholder_sort_key("StartValid"))
+
+    assert [ch.CardHolderID for ch in ordered] == [3, 1, 2]
+
+
+def test_cardholders_list_sort_by_cards(monkeypatch):
+    holders = [
+        make_cardholder(CardHolderID=1, Surname="High", Cards=[3000]),
+        make_cardholder(CardHolderID=2, Surname="None", Cards=[]),
+        make_cardholder(CardHolderID=3, Surname="Low", Cards=[1003]),
+    ]
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def getCardholders(self, params=None):
+            return holders
+
+    monkeypatch.setattr("act365.cli.Act365Client", FakeClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--username",
+            "user",
+            "--password",
+            "pass",
+            "--siteid",
+            "8539",
+            "cardholders",
+            "list",
+            "--sort-by",
+            "Cards",
+        ],
+        obj={},
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = [
+        line for line in result.output.splitlines() if line.startswith(("1", "2", "3"))
+    ]
+    assert [line.split()[0] for line in lines] == ["3", "1", "2"]
+
+
+def test_cardholders_list_rejects_unknown_sort_field(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--username",
+            "user",
+            "--password",
+            "pass",
+            "--siteid",
+            "8539",
+            "cardholders",
+            "list",
+            "--sort-by",
+            "NotAField",
+        ],
+        obj={},
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid value for '--sort-by'" in result.output


### PR DESCRIPTION
## Summary

Adds a `--sort-by` argument to `act365 cardholders list` so the listing can be ordered by any displayed column, ascending — e.g. `act365 cardholders list --sort-by Cards` orders by card number.

- Accepts any of the displayed columns (`CardHolderID`, `Forename`, `Surname`, `Email`, `Enabled`, `StartValid`, `EndValid`, `Cards`), case-insensitively; invalid fields are rejected with a Click usage error. Without `--sort-by`, output order is unchanged (API order).
- `Cards` sorts by each cardholder's lowest card number (`Cards` is a list).
- `StartValid`/`EndValid` sort chronologically by parsing the `DD/MM/YYYY HH:MM` strings, not lexically.
- String fields sort case-insensitively; cardholders without a value for the chosen field sort last.

## Testing

New `tests/test_cli.py`: unit tests for the sort key (Cards ordering, case-insensitive surnames, chronological dates) plus end-to-end `CliRunner` tests against a stubbed `Act365Client` asserting output row order and invalid-field rejection. black/isort/flake8 and pre-commit hooks pass. The two pre-existing failures in `test_barkside.py`/`test_client.py` are live-API assertions that fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)