### PR TITLE
fix: preserve true SiteID (0 = all-sites) instead of patching it

### DIFF
--- a/src/act365/cardholder.py
+++ b/src/act365/cardholder.py
@@ -65,7 +65,12 @@ class CardHolder(object):
         merged = dict(list(empty.items()) + list(dictionary.items()))
         for key in merged:
             setattr(self, key, merged[key])
-        if not self.SiteID:
+        # SiteID 0 is a legitimate value: an "all-sites" (global) cardholder.
+        # Only a genuinely absent SiteID (None) is invalid. Treating 0 as
+        # missing here is what forced callers to patch it to a specific site,
+        # which corrupts global cardholders on write-back (ACT365 then rejects
+        # the implied cross-site move).
+        if self.SiteID is None:
             raise ValueError("CardHolder SiteID is required")
         if not self.CustomerID:
             raise ValueError("CardHolder CustomerID is required")

--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -55,8 +55,10 @@ class Act365Client:
 
                 for ch in cardholders:
                     try:
-                        if ch.get("SiteID") == 0 or ch.get("SiteID") is None:
-                            ch["SiteID"] = self.siteid
+                        # Preserve the cardholder's true SiteID as returned by
+                        # ACT365 (0 = all-sites/global). Do NOT rewrite it to
+                        # this client's site — that corrupts global cardholders
+                        # and makes a later update look like a cross-site move.
                         self._CardHolders.append(CardHolder(ch))
                     except ValueError as e:
                         LOG.warning(

--- a/tests/test_cardholder.py
+++ b/tests/test_cardholder.py
@@ -99,6 +99,12 @@ def test_cardholder_requires_siteid():
         CardHolder({"CustomerID": 5622, "Groups": [27470]})
 
 
+def test_cardholder_allows_allsites_siteid():
+    # SiteID 0 = all-sites/global cardholder; must be accepted, not rejected.
+    ch = CardHolder({"SiteID": 0, "CustomerID": 5622, "Groups": [27470]})
+    assert ch.SiteID == 0
+
+
 def test_cardholder_requires_customerid():
     with pytest.raises(ValueError, match="CustomerID"):
         CardHolder({"SiteID": 8539, "Groups": [27470]})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import json
 import os
 from datetime import datetime, timedelta
 from random import randint
@@ -42,6 +43,37 @@ def act365_client():
     username = os.getenv("ACT365_USERNAME")
     password = os.getenv("ACT365_PASSWORD")
     return Act365Client(username=username, password=password, siteid=8539)
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self.text = json.dumps(payload)
+
+
+def test_get_cardholders_preserves_true_siteid(monkeypatch):
+    # ACT365's list endpoint returns SiteID 0 for all-sites/global cardholders.
+    # getCardholders must return that 0 unchanged, not rewrite it to the
+    # client's own site (8539) — doing so corrupts global cardholders and makes
+    # a later update look like a rejected cross-site move.
+    client = Act365Client(username="u", password="p", siteid=8539)
+    pages = [
+        [
+            {"CardHolderID": 1, "CustomerID": 5622, "SiteID": 0, "Groups": [1]},
+            {"CardHolderID": 2, "CustomerID": 5622, "SiteID": 9000, "Groups": [1]},
+        ],
+        [],
+    ]
+    calls = iter(pages)
+    monkeypatch.setattr(
+        client.client, "get", lambda *a, **k: _FakeResponse(next(calls))
+    )
+
+    holders = {ch.CardHolderID: ch for ch in client.getCardholders()}
+
+    assert holders[1].SiteID == 0
+    assert holders[2].SiteID == 9000
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #47

## Problem
`getCardholders()` rewrote any cardholder whose `SiteID` came back as `0`/`None` to the client's own site, and `CardHolder` validation rejected `SiteID == 0`. But `0` is a legitimate ACT365 value — an all-sites/global cardholder. Patching it corrupts the cardholder on read, so a later `updateCardholder` looks like a cross-site move and ACT365 rejects it ("In order to change a cardholder from one site to another ...").

Confirmed against live ACT365 (read-only): the list endpoint and `GET /cardholder/{id}` both return `SiteID: 0` for a global cardholder; only the client mangled it.

## Changes
- `CardHolder`: accept `SiteID == 0`; treat only `None` as missing.
- `getCardholders`: stop rewriting `SiteID`; return ACT365's value verbatim.
- Tests: `SiteID 0` is accepted; `getCardholders` preserves `0` and real sites.

## Downstream
jobdoneright/barkside#79 depends on this; needs the release that follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)