### PR TITLE
feat: add server-side getCardholder(id) via GET /cardholder/{id}

### DIFF
--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -68,6 +68,33 @@ class Act365Client:
 
         return self._CardHolders
 
+    def getCardholder(self, id):
+        """Fetch a single cardholder by ID via GET /cardholder/{id}.
+
+        A server-side lookup — no full paged walk of the directory — so callers
+        that already know the CardHolderID pay one request, not one per 100
+        cardholders. Returns a CardHolder, or None if the id is unknown (404) or
+        the response is not a single cardholder object.
+        """
+        response = self.client.get(f"{self.url}/cardholder/{id}")
+        if response.status_code != httpx.codes.OK:
+            return None
+        try:
+            ch = json.loads(response.text)
+        except json.JSONDecodeError:
+            return None
+        # The endpoint may answer an unknown id with an empty body or a list.
+        if not isinstance(ch, dict) or not ch:
+            return None
+        # Mirror getCardholders: SiteID 0 / missing means the querying site.
+        if ch.get("SiteID") == 0 or ch.get("SiteID") is None:
+            ch["SiteID"] = self.siteid
+        try:
+            return CardHolder(ch)
+        except ValueError as e:
+            LOG.warning(f"Skipping cardholder {ch.get('CardHolderID')}: {e}")
+            return None
+
     def getCardholderByEmail(self, email):
         self.getCardholders()
         for ch in self._CardHolders:
@@ -75,10 +102,10 @@ class Act365Client:
                 return ch
 
     def getCardholderById(self, id):
-        self.getCardholders()
-        for ch in self._CardHolders:
-            if ch.CardHolderID == id:
-                return ch
+        # Prefer the server-side single-cardholder endpoint (one request); the
+        # ACT365 API has no by-email equivalent, so getCardholderByEmail still
+        # walks the full directory.
+        return self.getCardholder(id)
 
     def createCardholder(self, cardholder: CardHolder | dict) -> int | None:
         if isinstance(cardholder, dict):

--- a/tests/test_get_cardholder.py
+++ b/tests/test_get_cardholder.py
@@ -1,0 +1,94 @@
+"""Unit tests for the server-side single-cardholder fetch (GET /cardholder/{id}).
+
+Uses pytest-httpx to mock both the auth login and the cardholder endpoint, so no
+live ACT365 account is needed. The point of getCardholder is that a caller who
+knows the CardHolderID pays one request instead of walking the whole directory.
+"""
+
+import pytest
+
+from act365.client import Act365Client
+
+BASE = "https://userapi.act365.eu/api"
+
+
+@pytest.fixture
+def login(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/account/login",
+        json={
+            "access_token": "test-token",
+            "token_type": "bearer",
+            "expires_in": 86399,
+        },
+    )
+
+
+def _cardholder(**overrides):
+    ch = {
+        "CardHolderID": 123,
+        "CustomerID": 5622,
+        "SiteID": 8539,
+        "Forename": "Test",
+        "Surname": "Holder",
+        "Email": "test@example.com",
+        "Groups": [27470],
+        "Cards": [1003],
+    }
+    ch.update(overrides)
+    return ch
+
+
+def _client():
+    return Act365Client(username="u", password="p", siteid=8539)
+
+
+def test_get_cardholder_found(login, httpx_mock):
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/cardholder/123", json=_cardholder()
+    )
+
+    ch = _client().getCardholder(123)
+
+    assert ch is not None
+    assert ch.CardHolderID == 123
+    assert ch.Email == "test@example.com"
+
+
+def test_get_cardholder_by_id_uses_single_endpoint_not_a_walk(login, httpx_mock):
+    # Only the single-cardholder endpoint is registered; a full-directory walk
+    # (GET /cardholder?skipover=...) would raise an unmatched-request error.
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/cardholder/123", json=_cardholder()
+    )
+
+    ch = _client().getCardholderById(123)
+
+    assert ch is not None and ch.CardHolderID == 123
+
+
+def test_get_cardholder_not_found_returns_none(login, httpx_mock):
+    httpx_mock.add_response(method="GET", url=f"{BASE}/cardholder/999", status_code=404)
+
+    assert _client().getCardholder(999) is None
+
+
+def test_get_cardholder_siteid_zero_normalised_to_query_site(login, httpx_mock):
+    # An all-sites (SiteID 0) cardholder: CardHolder() rejects a falsy SiteID, so
+    # the fetch must normalise 0 to the querying site (mirrors getCardholders).
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/cardholder/123", json=_cardholder(SiteID=0)
+    )
+
+    ch = _client().getCardholder(123)
+
+    assert ch is not None
+    assert ch.SiteID == 8539
+
+
+def test_get_cardholder_empty_body_returns_none(login, httpx_mock):
+    # An unknown id can answer 200 with an empty object rather than 404.
+    httpx_mock.add_response(method="GET", url=f"{BASE}/cardholder/123", json={})
+
+    assert _client().getCardholder(123) is None


### PR DESCRIPTION
getCardholderById / getCardholderByEmail both walked the entire paged
cardholder directory client-side, so any caller that already knew the
CardHolderID still paid a full ~14-request walk (and could trip ACT365's
rate limit when done in a loop).

Add getCardholder(id), a single GET /cardholder/{id}, and delegate
getCardholderById to it — one request instead of a walk. SiteID 0 / missing
is normalised to the querying site (mirrors getCardholders, and CardHolder
rejects a falsy SiteID); an unknown id (404 or empty body) returns None.
getCardholderByEmail still walks: the ACT365 API has no by-email lookup.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
