### PR TITLE
fix: getCardholder(id) must preserve all-sites SiteID (0), like getCardholders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ API documentation: https://act365api.docs.apiary.io/#
 - Date format throughout: `DD/MM/YYYY HH:MM` (defined as `STRPTIME_FMT` in `booking.py`)
 - The ACT365 API returns `DoorID` (singular int) when a booking has only one door, and `DoorIDs` (list) otherwise — the `Booking` dataclass handles this via `InitVar[DoorID]`
 - `deleteBooking` posts to `url + "2/Bookings"` (note the "2" suffix — this is intentional)
+- Cardholder `PIN` (verified against the live API, July 2026): both `GET /cardholder` (list) and `GET /cardholder/{id}` return the stored PIN in cleartext. `PUT /cardholder` replaces the whole record — sending `PIN: ""` **or omitting the PIN key** silently clears the stored PIN (`Success: true`, no rejection). There is no "leave PIN unchanged" at the API level; the only safe update pattern is fetch-modify-write (round-trip the GET response through the PUT).
+- Cardholder `SiteID` 0 means all-sites/global. Never rewrite it to a specific site — ACT365 rejects the resulting update as a cross-site move.
 
 ## Release Process
 

--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -77,6 +77,9 @@ class Act365Client:
         that already know the CardHolderID pay one request, not one per 100
         cardholders. Returns a CardHolder, or None if the id is unknown (404) or
         the response is not a single cardholder object.
+
+        The SiteID comes back exactly as ACT365 stores it (0 = all-sites), so
+        the returned object is safe to mutate and pass to updateCardholder.
         """
         response = self.client.get(f"{self.url}/cardholder/{id}")
         if response.status_code != httpx.codes.OK:
@@ -88,9 +91,10 @@ class Act365Client:
         # The endpoint may answer an unknown id with an empty body or a list.
         if not isinstance(ch, dict) or not ch:
             return None
-        # Mirror getCardholders: SiteID 0 / missing means the querying site.
-        if ch.get("SiteID") == 0 or ch.get("SiteID") is None:
-            ch["SiteID"] = self.siteid
+        # Preserve the cardholder's true SiteID as returned by ACT365
+        # (0 = all-sites/global), matching getCardholders. Rewriting 0 to
+        # this client's site makes a later update look like a cross-site
+        # move, which ACT365 rejects.
         try:
             return CardHolder(ch)
         except ValueError as e:
@@ -129,6 +133,18 @@ class Act365Client:
         return None
 
     def updateCardholder(self, cardholder: CardHolder | dict) -> bool:
+        """Update a cardholder via PUT /cardholder.
+
+        Returns True on success; raises ValueError with the API's ErrorMsg on
+        any failure.
+
+        PIN semantics (verified against the live API): the PUT replaces the
+        whole record. Sending PIN as "" — or omitting the key entirely —
+        CLEARS any stored PIN; ACT365 does not treat an absent PIN as "leave
+        unchanged" and does not reject empty-PIN updates. To preserve the PIN,
+        fetch the cardholder first (GET returns the stored PIN), mutate the
+        returned object, and pass it back here.
+        """
         if isinstance(cardholder, dict):
             data = cardholder
         elif isinstance(cardholder, CardHolder):

--- a/tests/test_get_cardholder.py
+++ b/tests/test_get_cardholder.py
@@ -74,9 +74,10 @@ def test_get_cardholder_not_found_returns_none(login, httpx_mock):
     assert _client().getCardholder(999) is None
 
 
-def test_get_cardholder_siteid_zero_normalised_to_query_site(login, httpx_mock):
-    # An all-sites (SiteID 0) cardholder: CardHolder() rejects a falsy SiteID, so
-    # the fetch must normalise 0 to the querying site (mirrors getCardholders).
+def test_get_cardholder_preserves_allsites_siteid(login, httpx_mock):
+    # An all-sites (SiteID 0) cardholder must keep SiteID 0, mirroring
+    # getCardholders. Rewriting it to the querying site makes a later
+    # updateCardholder look like a cross-site move, which ACT365 rejects.
     httpx_mock.add_response(
         method="GET", url=f"{BASE}/cardholder/123", json=_cardholder(SiteID=0)
     )
@@ -84,7 +85,22 @@ def test_get_cardholder_siteid_zero_normalised_to_query_site(login, httpx_mock):
     ch = _client().getCardholder(123)
 
     assert ch is not None
-    assert ch.SiteID == 8539
+    assert ch.SiteID == 0
+
+
+def test_get_cardholder_round_trips_pin(login, httpx_mock):
+    # ACT365 returns the stored PIN on GET, and a PUT with an empty/absent PIN
+    # clears it — so the fetched object must carry the PIN through to dict()
+    # for a safe fetch-modify-write update.
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/cardholder/123", json=_cardholder(PIN="4321")
+    )
+
+    ch = _client().getCardholder(123)
+
+    assert ch is not None
+    assert ch.PIN == "4321"
+    assert ch.dict()["PIN"] == "4321"
 
 
 def test_get_cardholder_empty_body_returns_none(login, httpx_mock):


### PR DESCRIPTION
Delivers the fix for a report (received via chat; no tracked GitHub/JIRA issue) that `updateCardholder()` fails when a `CardHolder` carries an empty PIN, with production syncs failing silently.

## Investigation (verified against the live ACT365 API)

- Both `GET /cardholder` (list) and `GET /cardholder/{id}` **do return the stored PIN**, so fetched cardholders already carry it.
- `PUT /cardholder` with `PIN: ""` is **not rejected** — it succeeds and **clears** the stored PIN. Omitting the PIN key behaves identically, so a client-side "skip PIN when empty" cannot preserve anything. The only safe update pattern is fetch-modify-write.
- `updateCardholder()` has raised `ValueError` with the API's `ErrorMsg` since v1.4.0 — it never returned `False`; the silent failure is caller-side exception swallowing.

## The actual bug fixed here

`getCardholder(id)` rewrote `SiteID: 0` (all-sites/global) to the querying client's site, contradicting #48 which fixed the same thing on the list path. A fetch-modify-write update of a global cardholder then looked like a cross-site move, which ACT365 rejects — a plausible source of the reported update failures, since the vast majority of cardholders in the reference account are all-sites.

## Changes

- `getCardholder(id)` now preserves the SiteID exactly as ACT365 returns it (verified read-only against the live API: an all-sites cardholder now comes back with `SiteID == 0`).
- Replaced the test asserting the old rewrite with one asserting preservation, and added a PIN round-trip regression test.
- Documented the PIN clear-on-empty/omit semantics on `updateCardholder` and in CLAUDE.md.

## Testing

- `pytest`: 30 passed, 17 skipped (live tests) offline; flake8/isort/black clean; pre-commit hooks passed.
- Live read-only verification of SiteID preservation via `getCardholder` on an all-sites cardholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)