### PR TITLE
feat: generous timeouts, retry idempotent requests on timeout, typed auth errors

### DIFF
--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -15,18 +15,63 @@ logging.basicConfig(
 )
 LOG = logging.getLogger(__name__)
 
+# ACT365's Azure backend can be very slow (logins of 15s+ observed overnight),
+# so the read timeout must be generous; httpx's 5s default caused nightly
+# ReadTimeouts in production. Connect stays tighter — an unreachable host
+# should fail fast.
+DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+# Pause before the single retry of a timed-out idempotent request, giving a
+# briefly-overloaded backend a moment to recover.
+RETRY_SLEEP_SECONDS = 2
+
+
+class Act365Error(Exception):
+    """Base class for ACT365 client errors."""
+
+
+class Act365AuthError(Act365Error):
+    """Raised when ACT365 login fails or credentials are missing."""
+
 
 class Act365Client:
-    def __init__(self, username, password, siteid, url="https://userapi.act365.eu/api"):
+    def __init__(
+        self,
+        username,
+        password,
+        siteid,
+        url="https://userapi.act365.eu/api",
+        timeout=None,
+    ):
         self.username = username
         self.password = password
         self.siteid = siteid
         self.url = url
 
         self.auth = Act365Auth(username, password, url=url)
-        self.client = httpx.Client(auth=self.auth)
+        self.client = httpx.Client(
+            auth=self.auth,
+            timeout=timeout if timeout is not None else DEFAULT_TIMEOUT,
+            # Transport-level retries cover connection failures only (never a
+            # request that reached the server), so they are safe for all verbs.
+            transport=httpx.HTTPTransport(retries=2),
+        )
 
         self._CardHolders = list()
+
+    def _request_with_retry(self, method, url, **kwargs):
+        """Send a request, retrying once on timeout.
+
+        Only for idempotent requests (GETs and the full-overwrite cardholder
+        PUT): a timed-out request may still have been applied server-side, so
+        a non-idempotent POST must not go through here.
+        """
+        try:
+            return self.client.request(method, url, **kwargs)
+        except httpx.TimeoutException:
+            LOG.warning(f"{method} {url} timed out; retrying once")
+            sleep(RETRY_SLEEP_SECONDS)
+            return self.client.request(method, url, **kwargs)
 
     def getCardholders(self, params={}):
         # ?customerid={customerid}
@@ -45,7 +90,9 @@ class Act365Client:
         more_to_get = True
         while more_to_get:
             params["skipover"] = len(self._CardHolders)
-            response = self.client.get(self.url + "/cardholder", params=params)
+            response = self._request_with_retry(
+                "GET", self.url + "/cardholder", params=params
+            )
 
             if response.status_code == httpx.codes.OK:
                 cardholders = json.loads(response.text)
@@ -81,7 +128,7 @@ class Act365Client:
         The SiteID comes back exactly as ACT365 stores it (0 = all-sites), so
         the returned object is safe to mutate and pass to updateCardholder.
         """
-        response = self.client.get(f"{self.url}/cardholder/{id}")
+        response = self._request_with_retry("GET", f"{self.url}/cardholder/{id}")
         if response.status_code != httpx.codes.OK:
             return None
         try:
@@ -152,7 +199,8 @@ class Act365Client:
         else:
             raise TypeError("cardholder must be a CardHolder object or a dictionary")
 
-        response = self.client.put(self.url + "/cardholder", json=data)
+        # A full-overwrite PUT is idempotent, so a timeout retry is safe.
+        response = self._request_with_retry("PUT", self.url + "/cardholder", json=data)
         LOG.debug(f"updateCardholder response: {response.status_code} {response.text}")
         if response.status_code == httpx.codes.OK and response.json().get(
             "Success", False
@@ -170,7 +218,9 @@ class Act365Client:
         more_to_get = True
         while more_to_get:
             params["skipover"] = len(sites)
-            response = self.client.get(self.url + "/Bookingsites", params=params)
+            response = self._request_with_retry(
+                "GET", self.url + "/Bookingsites", params=params
+            )
 
             if response.status_code == httpx.codes.OK:
                 _sites = json.loads(response.text)
@@ -187,8 +237,8 @@ class Act365Client:
         return sites
 
     def getBookingSiteDoors(self, siteid):
-        response = self.client.get(
-            self.url + "/Bookingdoors", params={"siteid": siteid}
+        response = self._request_with_retry(
+            "GET", self.url + "/Bookingdoors", params={"siteid": siteid}
         )
 
         if response.status_code == httpx.codes.OK:
@@ -208,8 +258,8 @@ class Act365Client:
         return response
 
     def getBooking(self, siteid, id):
-        response = self.client.get(
-            self.url + "/Bookings", params={"siteid": siteid, "bookingID": id}
+        response = self._request_with_retry(
+            "GET", self.url + "/Bookings", params={"siteid": siteid, "bookingID": id}
         )
         LOG.debug(f"Response: {response.status_code} {response.text}")
         if response.text == "null" or response.status_code != httpx.codes.OK:
@@ -245,7 +295,7 @@ class Act365Client:
         more_to_get = True
         while more_to_get:
             params["skipover"] = len(results)
-            response = self.client.get(self.url + path, params=params)
+            response = self._request_with_retry("GET", self.url + path, params=params)
 
             if response.status_code == httpx.codes.OK:
                 rs = json.loads(response.text)
@@ -283,7 +333,7 @@ class Act365Auth(httpx.Auth):
     ):
 
         if username is None or password is None:
-            raise Exception
+            raise Act365AuthError("ACT365 username and password are required")
         self.username = username
         self.password = password
         self.grant_type = grant_type
@@ -322,7 +372,9 @@ class Act365Auth(httpx.Auth):
             elif response.status_code == httpx.codes.TOO_MANY_REQUESTS:
                 sleep(65)
             else:
-                raise Exception
+                raise Act365AuthError(
+                    f"ACT365 login failed: {response.status_code} {response.text}"
+                )
 
     def auth_flow(self, request):
         if self.access_token is None:

--- a/src/act365/client.py
+++ b/src/act365/client.py
@@ -60,15 +60,19 @@ class Act365Client:
         self._CardHolders = list()
 
     def _request_with_retry(self, method, url, **kwargs):
-        """Send a request, retrying once on timeout.
+        """Send a request, retrying once on a read timeout.
 
         Only for idempotent requests (GETs and the full-overwrite cardholder
         PUT): a timed-out request may still have been applied server-side, so
         a non-idempotent POST must not go through here.
+
+        Only ReadTimeout is retried — the slow-backend failure this exists
+        for. Connect timeouts are already retried by the transport and must
+        otherwise fail fast; write/pool timeouts surface immediately.
         """
         try:
             return self.client.request(method, url, **kwargs)
-        except httpx.TimeoutException:
+        except httpx.ReadTimeout:
             LOG.warning(f"{method} {url} timed out; retrying once")
             sleep(RETRY_SLEEP_SECONDS)
             return self.client.request(method, url, **kwargs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,8 +66,10 @@ def test_get_cardholders_preserves_true_siteid(monkeypatch):
         [],
     ]
     calls = iter(pages)
+    # getCardholders sends its GETs via client.request (through the timeout
+    # retry helper), so that is the interception point.
     monkeypatch.setattr(
-        client.client, "get", lambda *a, **k: _FakeResponse(next(calls))
+        client.client, "request", lambda *a, **k: _FakeResponse(next(calls))
     )
 
     holders = {ch.CardHolderID: ch for ch in client.getCardholders()}

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -5,19 +5,12 @@ import httpx
 import json5
 import pytest
 
-from act365.client import Act365Auth
+from act365.client import Act365Auth, Act365AuthError
 
 
 def test_act365_auth_failures():
-    try:
+    with pytest.raises(Act365AuthError):
         _ = Act365Auth(username=None, password=None)
-    except Exception as e:
-        assert type(e) is Exception
-
-    try:
-        _ = Act365Auth(username="bad", password="credenrials")
-    except Exception as e:
-        assert type(e) is Exception
 
 
 @pytest.mark.skipif(

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,128 @@
+"""Unit tests for timeout configuration and the single timeout retry.
+
+ACT365's backend has been observed taking 15s+ per request overnight, so the
+client carries a generous default read timeout and retries idempotent requests
+(GETs, the full-overwrite cardholder PUT) once on timeout. Non-idempotent
+creation POSTs are never retried: a timed-out request may still have been
+applied server-side.
+
+pytest-httpx intercepts at HTTPTransport.handle_request, above the transport's
+connect-retry layer, so a mocked timeout exercises exactly one application-level
+retry.
+"""
+
+import httpx
+import pytest
+
+from act365.client import DEFAULT_TIMEOUT, Act365Auth, Act365AuthError, Act365Client
+
+BASE = "https://userapi.act365.eu/api"
+
+
+@pytest.fixture
+def login(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/account/login",
+        json={
+            "access_token": "test-token",
+            "token_type": "bearer",
+            "expires_in": 86399,
+        },
+    )
+
+
+@pytest.fixture
+def no_retry_sleep(monkeypatch):
+    monkeypatch.setattr("act365.client.sleep", lambda seconds: None)
+
+
+def _client(**kwargs):
+    return Act365Client(username="u", password="p", siteid=8539, **kwargs)
+
+
+def _cardholder():
+    return {
+        "CardHolderID": 123,
+        "CustomerID": 5622,
+        "SiteID": 8539,
+        "Forename": "Test",
+        "Surname": "Holder",
+        "Email": "test@example.com",
+        "Groups": [27470],
+        "Cards": [1003],
+    }
+
+
+def test_default_timeout_is_generous():
+    client = _client()
+    assert client.client.timeout == DEFAULT_TIMEOUT
+    assert DEFAULT_TIMEOUT.read == 30.0
+    assert DEFAULT_TIMEOUT.connect == 10.0
+
+
+def test_timeout_kwarg_overrides_default():
+    custom = httpx.Timeout(3.0)
+    client = _client(timeout=custom)
+    assert client.client.timeout == custom
+
+
+def test_get_cardholder_retries_once_on_timeout(login, httpx_mock, no_retry_sleep):
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("timed out"), method="GET", url=f"{BASE}/cardholder/123"
+    )
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/cardholder/123", json=_cardholder()
+    )
+
+    ch = _client().getCardholder(123)
+
+    assert ch is not None
+    assert ch.CardHolderID == 123
+
+
+def test_get_cardholder_raises_after_second_timeout(login, httpx_mock, no_retry_sleep):
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("timed out"), method="GET", url=f"{BASE}/cardholder/123"
+    )
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("timed out again"), method="GET", url=f"{BASE}/cardholder/123"
+    )
+
+    with pytest.raises(httpx.ReadTimeout):
+        _client().getCardholder(123)
+
+
+def test_update_cardholder_retries_once_on_timeout(login, httpx_mock, no_retry_sleep):
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("timed out"), method="PUT", url=f"{BASE}/cardholder"
+    )
+    httpx_mock.add_response(
+        method="PUT", url=f"{BASE}/cardholder", json={"Success": True}
+    )
+
+    assert _client().updateCardholder(_cardholder()) is True
+
+
+def test_create_cardholder_is_not_retried_on_timeout(login, httpx_mock, no_retry_sleep):
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("timed out"), method="POST", url=f"{BASE}/cardholder"
+    )
+
+    with pytest.raises(httpx.ReadTimeout):
+        _client().createCardholder(_cardholder())
+
+    creates = [
+        r for r in httpx_mock.get_requests() if r.url.path.endswith("/cardholder")
+    ]
+    assert len(creates) == 1
+
+
+def test_login_failure_raises_typed_error(httpx_mock):
+    httpx_mock.add_response(
+        method="POST", url=f"{BASE}/account/login", status_code=400, text="bad creds"
+    )
+
+    auth = Act365Auth(username="bad", password="credentials")
+    with pytest.raises(Act365AuthError, match="login failed: 400"):
+        auth.get_token()

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -93,6 +93,24 @@ def test_get_cardholder_raises_after_second_timeout(login, httpx_mock, no_retry_
         _client().getCardholder(123)
 
 
+def test_connect_timeout_is_not_retried_by_the_helper(
+    login, httpx_mock, no_retry_sleep
+):
+    # Connect timeouts are the transport's job (HTTPTransport(retries=2)) and
+    # must otherwise fail fast — the helper retries only read timeouts.
+    httpx_mock.add_exception(
+        httpx.ConnectTimeout("connect timed out"),
+        method="GET",
+        url=f"{BASE}/cardholder/123",
+    )
+
+    with pytest.raises(httpx.ConnectTimeout):
+        _client().getCardholder(123)
+
+    gets = [r for r in httpx_mock.get_requests() if r.method == "GET"]
+    assert len(gets) == 1
+
+
 def test_update_cardholder_retries_once_on_timeout(login, httpx_mock, no_retry_sleep):
     httpx_mock.add_exception(
         httpx.ReadTimeout("timed out"), method="PUT", url=f"{BASE}/cardholder"


### PR DESCRIPTION
## Problem

Consumers of this client (barkside's hourly `update_cardholder_windows` cron) fail with `httpx.ReadTimeout` during ACT365's overnight slow periods — 6 failed cron runs in the last 30 days, all between 21:55 and 03:55 UTC. The client uses httpx's default 5s read timeout for every call except login (90s), and ACT365 logins of 15s+ have been observed in production logs, so 5s for data calls is far too tight. There are no retries, and auth failures raise bare `Exception`.

## Changes

- **Explicit generous timeout**: `httpx.Timeout(30.0, connect=10.0)` default on the shared client, overridable via a new `timeout=` constructor kwarg on `Act365Client`.
- **Connect retries**: `httpx.HTTPTransport(retries=2)` — retries connection failures only (never a request that reached the server), safe for all verbs.
- **One retry on read timeout for idempotent requests** via `_request_with_retry`: all GETs (`getCardholder`, `getCardholders` pages, booking reads, `_getAll`) and `updateCardholder`'s full-overwrite PUT. Only `httpx.ReadTimeout` is retried (per Copilot review): connect timeouts stay with the transport's retry layer and otherwise fail fast; write/pool timeouts surface immediately. `createCardholder`'s POST is deliberately **not** retried — a timed-out create may still have been applied server-side (duplicate-creation risk).
- **Typed errors**: new `Act365Error` / `Act365AuthError`, replacing the two bare `raise Exception` in `Act365Auth`, so callers can catch auth failures meaningfully.

## Tests

`tests/test_timeouts.py` (pytest-httpx, no live calls): default/custom timeout config, GET retry then success, second timeout propagates, connect timeout not retried by the helper, PUT retry, POST not retried (single request asserted), typed login failure. Existing `test_client.py` monkeypatch updated to the new `client.request` interception point.

`pytest`: 38 passed, 17 skipped (integration, no creds). flake8/black/isort clean via pre-commit.

Part of the fix for the nightly cron timeouts alongside jobdoneright/barkside#110 (per-appointment error isolation); barkside refreshes its lock to pick this up once it releases as v1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)